### PR TITLE
Fix compatibility issue with Combat Carousel (Issue #16)

### DIFF
--- a/control-concealer.js
+++ b/control-concealer.js
@@ -136,7 +136,7 @@
 				}
 				else{
 					hiddencontrols.push({});
-					const tools = subcontrols[i].getElementsByClassName("control-tool");
+					const tools = subcontrols[i]?.getElementsByClassName("control-tool") ?? [];
 					let toolshidden = false;
 					for (let j = 0; j < tools.length; j++) {
 						const tool = tools[j];
@@ -242,7 +242,7 @@
 			//disable all hidden status
 			for (let i = 0; i < scenecontrols.length; i++) {
 				this.toggle_hidden(scenecontrols[i], false);
-				const tools = subcontrols[i].getElementsByClassName("control-tool");
+				const tools = subcontrols[i]?.getElementsByClassName("control-tool") ?? [];
 				for (let j = 0; j < tools.length; j++) {
 					this.toggle_hidden(tools[j], false);
 				}


### PR DESCRIPTION
This fixes issue #16 

Since Combat Carousel is a toggle (and thus has no subcontrols), Control Concealer was trying to access `undefined.getElementsByClassName("control-tool")` in two places

Pretty simple fix! Wish I'd taken a look sooner.

Note that I did *not* bump the version to 1.2.3 - you probably still want to do that!